### PR TITLE
update(groups.yaml)

### DIFF
--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -1,79 +1,84 @@
 contest:
+  - name: ICPC 2024 成都赛站
+    groupid: 557665508
+    owner: 电子科技大学
+    notes: 2024 年 ICPC 成都赛站官方群
+
+  - name: ICPC 2024 南京赛站
+    groupid: 1070161797
+    owner: 南京航空航天大学
+    notes: 2024 年 ICPC 南京赛站官方群
+
+  - name: ICPC 2024 杭州赛站
+    groupid: 296912548
+    owner: 杭州师范大学
+    notes: 2024 年 ICPC 杭州赛站官方群
+
+  - name: ICPC 2024 上海赛站
+    groupid: 1011465061
+    owner: 上海大学
+    notes: 2024 年 ICPC 上海赛站官方群
+
+  - name: ICPC 2024 沈阳赛站
+    groupid: 215015026
+    owner: 东北大学
+    notes: 2024 年 ICPC 沈阳赛站官方群
+
+  - name: ICPC 2024 昆明赛站
+    groupid: 733568804
+    owner: 云南大学
+    notes: 2024 年 ICPC 昆明赛站官方群
+
+  - name: ICPC 西安赛站
+    groupid: 665674380
+    owner: 西北工业大学
+    notes: 本群为原 2023 年西安赛站群，今年是否复用暂时未知
+
+  - name: CCPC 2024 哈尔滨赛站
+    groupid: 894279297
+    owner: 东北林业大学
+    notes: 2024 年 CCPC 哈尔滨赛站官方群
+
+  - name: CCPC 2024 济南赛站
+    groupid: 725818225
+    owner: 山东大学
+    notes: 2024 年 CCPC 济南赛站官方群
+
+  - name: CCPC 2024 重庆赛站
+    groupid: 686756102
+    owner: 重庆大学
+    notes: 2024 年 CCPC 重庆赛站官方群
+
+  - name: CCPC 2024 郑州赛站
+    groupid: 660800728
+    owner: 郑州轻工业大学
+    notes: 2024 年 CCPC 郑州赛站官方群
+
   - name: 银川站民间群
     groupid: 209518094
     owner: megumin
     notes: 来NXIST,学习开时光机和交100%查重的代码
 
-  - name: ICPC 西安赛站
-    groupid: 665674380
-    owner: 西北工业大学
-    # notes:
-
-  - name: 20XX icpc西安 肉夹馍
+  - name: ICPC 20XX 西安 肉夹馍
     groupid: 533499490
     owner: 蕶碎の記憶
     notes: 西安赛区民间群
-    
-  - name: CCPC重庆赛站
-    groupid: 686756102
-    owner: 重庆大学
-    notes: CCPC重庆赛站官方群
 
-  - name: ICPC 杭州赛站
-    groupid: 296912548
-    owner: 杭州师范大学
-    notes: ICPC 杭州赛站官方群
-    
-  - name: CCPC国赛（济南）
-    groupid: 725818225
-    owner: 山东大学
-    notes: CCPC济南赛站官方群
-
-  - name: ICPC济南赛站
+  - name: ICPC 2023 济南赛站
     groupid: 875213125
     owner: 齐鲁工业大学（山东省科学院）
-    notes: ICPC济南赛站官方群
+    notes: 原 2023 ICPC 济南赛站官方群
 
-  - name: 2024年ICPC全国邀请赛(武汉)
+  - name: ICPC 2024 邀请赛武汉赛站
     groupid: 144961450
     owner: 武汉大学
-    notes: 2024年ICPC全国邀请赛武汉赛区官方群
+    notes: 2024 年 ICPC 全国邀请赛武汉赛区官方群
 
-  - name: 2021年度（ICPC）江西省程序设计竞赛
-    groupid: 1025935124
-    owner: 江西师范大学
-    # notes:
-
-  - name: 20XX-ICPC南京站
-    groupid: 1070161797
-    owner: 南京航空航天大学
-    notes: 南京站参赛选手群，每年复用
-
-  - name: ICPC昆明赛站
-    groupid: 733568804
-    owner: 云南大学
-    notes: 2024年ICPC昆明赛站官方群
-    
-  - name: CCPC郑州邀请赛暨河南省赛
+  - name: CCPC 2024 邀请赛郑州赛站暨河南省赛
     groupid: 1158490493
     owner: 郑州轻工业大学
-    notes: 河南省赛群
+    notes: 2024 年 CCPC 全国邀请赛郑州赛区官方群
 
-  - name: 2024ICPC上海站
-    groupid: 1011465061
-    owner: 上海大学
-    notes: 2024年ICPC上海站官方群
-
-  - name: 2024年CCPC郑州站
-    groupid: 660800728
-    owner: 郑州轻工业大学
-    notes: 2024年CCPC郑州赛站官方群
-
-  - name: ICPC成都赛站
-    groupid: 557665508 
-    owner: 电子科技大学
-    notes: 2024年ICPC成都赛站官方群
-    
 algo:
   - name: Universal Cup 中文通知群
     groupid: 138092996
@@ -83,7 +88,7 @@ algo:
       致力于给有志于提高算法竞赛水平的队伍提供实战演练。  
       通过和出题团队合作，我们会使用尚未公开的题目举办一系列的镜像赛的方式。  
       赛事网站 https://ucup.ac 欢迎大家随时报名。
-      
+
   - name: 代码源算法交流群
     groupid: 137358724
     owner: wls
@@ -133,7 +138,7 @@ algo:
     groupid: 215089433
     owner: 教练
     notes: CCPC教练群
-    
+
   - name: 算法竞赛进阶指南读者群
     groupid: 650836280
     owner: lyd
@@ -143,7 +148,7 @@ algo:
     groupid: 1091497622
     owner: Macesuted
     notes: 学术群,HydroOJ用户
-    
+
   - name: 2021-ICPC网络预选赛教练群
     groupid: 981342367
     owner: 北京大学
@@ -153,12 +158,12 @@ algo:
     groupid: 631401747
     owner: LOJ
     # notes:
-    
+
   - name: MINIEYE杯中超联赛-1群
     groupid: 805983250
     owner: 杭州电子科技大学
     notes: 杭电多校群
-    
+
   - name: 牛客周赛1群
     groupid: 771094401
     owner: 神崎兰子
@@ -324,7 +329,7 @@ game:
     groupid: 981102220
     owner: absi2011
     notes: 杀戮尖塔群
-  
+
   - name: acm邦布交流群
     groupid: 849679220
     owner: 信含
@@ -334,7 +339,7 @@ game:
     groupid: 118563895
     owner: 叁纔
     notes: ph，咚咚谜，扫雷，数独，见证者，BIY，各种解谜都可以来！
-    
+
 job:
   - name: acmer秋招冲冲冲
     groupid: 1163137693
@@ -365,7 +370,7 @@ job:
     groupid: 700968569
     owner: megumin & cch
     # notes:
-    
+
   - name: 少儿编程/信息学竞赛教培交流群
     groupid: 829085623
     owner: 云哥


### PR DESCRIPTION
重修了赛站的名称以及赛站顺序（ICPC->CCPC->过期官方群/民间群 & 按照时间排序）
添加了CCPC哈尔滨赛站的信息
删除了过于老旧（并且已经搜索不到的）21年江西省赛群

全部群聊信息已经经过验证。

目前 2024 XCPC 赛事群缺失：ICPC香港站、CCPC女生专场