### PR TITLE
feat(data/groups.yaml):维护群聊信息

### DIFF
--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -181,7 +181,7 @@ algo:
 
   - name: 牛客周赛1群
     groupid: 771094401
-    owner: 智乃
+    owner: 神崎兰子
     #notes: 牛客周赛交流群
 
   - name: 牛客周赛2群
@@ -200,7 +200,7 @@ algo:
 
   - name: 牛客练习赛群
     groupid: 557276186
-    owner: 沙烬
+    owner: 智乃
     #notes: 牛客月赛交流群
 
   - name: 交上去就AC群
@@ -793,3 +793,8 @@ others:
     groupid: 234208873
     owner: 俊杰Charles
     notes: 福瑞（Furry）群，不开放加群，加群请联系群主QQ490168650
+
+  - name: ACM 单身派对
+    groupid: 611972890
+    owner: Silencer76
+    notes: 单身ACMER请进，欢迎分享恋爱故事

--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -181,7 +181,7 @@ algo:
 
   - name: 牛客周赛1群
     groupid: 771094401
-    owner: 智乃
+    owner: 神崎兰子
     #notes: 牛客周赛交流群
 
   - name: 牛客周赛2群

--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -39,11 +39,6 @@ contest:
     owner: 西北工业大学
     notes: 本群为原 2023 年西安赛站群，今年是否复用暂时未知
 
-  - name: CCPC 2024 哈尔滨赛站
-    groupid: 894279297
-    owner: 东北林业大学
-    notes: 2024 年 CCPC 哈尔滨赛站官方群
-
   - name: CCPC 2024 济南赛站
     groupid: 725818225
     owner: 山东大学

--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -181,13 +181,17 @@ algo:
 
   - name: 牛客周赛1群
     groupid: 771094401
-    owner: 神崎兰子
+    owner: 智乃
     #notes: 牛客周赛交流群
 
   - name: 牛客周赛2群
     groupid: 100237444
-    owner: 智乃
+    owner: Silencer76
     #notes: 牛客周赛交流群
+
+  - name: 牛客周赛3群
+    groupid: 559723446
+    owner: Silencer76
 
   - name: 牛客月赛群
     groupid: 482533117
@@ -218,7 +222,7 @@ algo:
     groupid: 174495261
     owner: Null_Resot
     notes: 目的为xcpc入门选手提供帮助
-    
+
 game:
   - name: acm雀魂群
     groupid: 967906418
@@ -393,7 +397,7 @@ game:
     groupid: 515355340
     owner: poursoul
     notes: osu 同好群，其他音游玩家也欢迎加入
-    
+
 job:
   - name: acmer秋招冲冲冲
     groupid: 1163137693

--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -1,43 +1,43 @@
 contest:
-  - name: ICPC 2024 成都赛站
+  - name: ICPC 2025 武汉赛站
+    groupid: 144961450
+    owner: 武汉大学
+    notes: 2025 年 ICPC 武汉赛站官方群
+
+  - name: ICPC 2025 成都赛站
     groupid: 557665508
     owner: 电子科技大学
-    notes: 2024 年 ICPC 成都赛站官方群
+    notes: 2025 年 ICPC 成都赛站官方群
 
-  - name: ICPC 2024 南京赛站
+  - name: ICPC 2025 南京赛站
     groupid: 1070161797
     owner: 南京航空航天大学
-    notes: 2024 年 ICPC 南京赛站官方群
+    notes: 2025 年 ICPC 南京赛站官方群
 
-  - name: ICPC 2024 杭州赛站
+  - name: ICPC 2025 杭州赛站
     groupid: 296912548
     owner: 杭州师范大学
-    notes: 2024 年 ICPC 杭州赛站官方群
+    notes: 2025 年 ICPC 杭州赛站官方群
 
-  - name: ICPC 2024 上海赛站
+  - name: ICPC 2025 上海赛站
     groupid: 1011465061
     owner: 上海大学
-    notes: 2024 年 ICPC 上海赛站官方群
+    notes: 2025 年 ICPC 上海赛站官方群
 
-  - name: ICPC 2024 沈阳赛站
+  - name: ICPC 2025 沈阳赛站
     groupid: 215015026
     owner: 东北大学
-    notes: 2024 年 ICPC 沈阳赛站官方群
+    notes: 2025 年 ICPC 沈阳赛站官方群
 
-  - name: ICPC 2024 昆明赛站
-    groupid: 733568804
-    owner: 云南大学
-    notes: 2024 年 ICPC 昆明赛站官方群
-
-  - name: ICPC 2024 香港赛站
+  - name: ICPC 2025 香港赛站
     groupid: 697602399
     owner: 香港理工大学、香港城市大学
-    notes: 2024 年 ICPC 香港赛站官方群
+    notes: 2025 年 ICPC 香港赛站官方群
 
-  - name: ICPC 西安赛站
+  - name: ICPC 2025 西安赛站
     groupid: 665674380
     owner: 西北工业大学
-    notes: 本群为原 2023 年西安赛站群，今年是否复用暂时未知
+    notes: 2025 年 ICPC 西安赛站官方群
 
   - name: CCPC 2024 济南赛站
     groupid: 725818225
@@ -73,6 +73,11 @@ contest:
     groupid: 533499490
     owner: 蕶碎の記憶
     notes: 西安赛区民间群
+
+  - name: ICPC 2024 昆明赛站
+    groupid: 733568804
+    owner: 云南大学
+    notes: 原 2024 年 ICPC 昆明赛站官方群
 
   - name: ICPC 2023 济南赛站
     groupid: 875213125


### PR DESCRIPTION
1.三天前有关牛客的 commit 对于群聊的 owner 维护错了，现在修正了。
2.删除了 CCPC 哈尔滨
3.根据 ICPC 会议纲要将 2025 会举办 ICPC 的赛站群全都重命名了 2025（默认不换群，换群再维护），加入了武汉，后移了昆明。
4.新增了一个 ACM 单身群
cc @1804040636 @ReiAccept 