### PR TITLE
remove(data/groups.yaml):移除了群聊“acmer 烧友寻医问诊”

### DIFF
--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -704,11 +704,6 @@ others:
     owner: 云哥
     notes: 原牛客多校&江莉粉丝群
 
-  - name: acmer 烧友寻医问诊
-    groupid: 653296942
-    owner: whd
-    notes: 新冠互助治疗群
-
   - name: acmer 萝莉控发癫群
     groupid: 646333957
     owner: 严格鸽


### PR DESCRIPTION
原因：接到反馈，该群已经不可被搜索。疑似已经被解散。
需要确认&审核。