### PR TITLE
Fix contests JSON trailing commas

### DIFF
--- a/data/contests.json
+++ b/data/contests.json
@@ -12,7 +12,7 @@
     "startTime": 1777687200000,
     "duration": 18000,
     "organizer": "西北工业大学",
-    "board_url": "https://board.xcpcio.com/icpc/51st/xian-invitational",
+    "board_url": "https://board.xcpcio.com/icpc/51st/xian-invitational"
   },
   {
     "name": "2026 ICPC 深圳邀请赛",
@@ -21,7 +21,7 @@
     "duration": 18000,
     "organizer": "香港中文大学（深圳）",
     "contest_url": "https://icpc.pku.edu.cn/tzgg/dc29e1fce89f4fc8adae033373332542.htm",
-    "board_url": "https://board.xcpcio.com/icpc/51st/shenzhen-invitational",
+    "board_url": "https://board.xcpcio.com/icpc/51st/shenzhen-invitational"
   },
   {
     "name": "USTCPC2026",


### PR DESCRIPTION
修复 data/contests.json 中两个尾随逗号，避免 GitHub Pages 构建失败。\n\n验证：`node -e "for (const f of ['data/groups.json','data/contests.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json OK')"`